### PR TITLE
Read pluginConfigs path from Dalamud

### DIFF
--- a/plugin/Dalamud.cs
+++ b/plugin/Dalamud.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Numerics;
 using System.IO;
 using System;
-using Dalamud.Configuration;
 
 namespace MaterialUI {
 	public class DalamudStyle {
@@ -128,13 +127,12 @@ namespace MaterialUI {
 			};
 			
 			// special edits for penumbra window setting
-			try
-			{
-				string configPath = Path.Combine(main.pluginInterface.ConfigDirectory.FullName, "../Penumbra.json");
+			try {
+				string configPath = $"{main.pluginInterface.ConfigFile.DirectoryName}/Penumbra.json";
 				dynamic penumbraData = JsonConvert.DeserializeObject(File.ReadAllText(configPath));
 				string collection = (string)penumbraData?.CurrentCollection;
 				
-				string collectionPath = Path.Combine(main.pluginInterface.ConfigDirectory.FullName, "../Penumbra/collections/" + collection + ".json");
+				string collectionPath = $"{main.pluginInterface.ConfigFile.DirectoryName}/Penumbra/collections/{collection}.json";
 				dynamic collectionData = JsonConvert.DeserializeObject(File.ReadAllText(collectionPath));
 				if(collectionData.Settings["Material UI"].Settings["Selected Window"] == 1) {
 					style.WindowBorderSize = 2;

--- a/plugin/Dalamud.cs
+++ b/plugin/Dalamud.cs
@@ -7,10 +7,12 @@ using System.Collections.Generic;
 using System.Numerics;
 using System.IO;
 using System;
+using Dalamud.Configuration;
 
 namespace MaterialUI {
 	public class DalamudStyle {
-		public static void Apply(Config config, Dictionary<string, int> styleOverrides) {
+		public static void Apply(MaterialUI main, Dictionary<string, int> styleOverrides) {
+			Config config = main.config;
 			Vector4 accent = new Vector4(config.color.X, config.color.Y, config.color.Z, 1);
 			Vector4 accentHalf = accent * new Vector4(0.5f, 0.5f, 0.5f, 1);
 			
@@ -126,12 +128,13 @@ namespace MaterialUI {
 			};
 			
 			// special edits for penumbra window setting
-			try {
-				string configPath = Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "/XIVLauncher/PluginConfigs/Penumbra.json");
+			try
+			{
+				string configPath = Path.Combine(main.pluginInterface.ConfigDirectory.FullName, "../Penumbra.json");
 				dynamic penumbraData = JsonConvert.DeserializeObject(File.ReadAllText(configPath));
 				string collection = (string)penumbraData?.CurrentCollection;
 				
-				string collectionPath = Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "/XIVLauncher/PluginConfigs/Penumbra/collections/" + collection + ".json");
+				string collectionPath = Path.Combine(main.pluginInterface.ConfigDirectory.FullName, "../Penumbra/collections/" + collection + ".json");
 				dynamic collectionData = JsonConvert.DeserializeObject(File.ReadAllText(collectionPath));
 				if(collectionData.Settings["Material UI"].Settings["Selected Window"] == 1) {
 					style.WindowBorderSize = 2;

--- a/plugin/MaterialUI.cs
+++ b/plugin/MaterialUI.cs
@@ -61,9 +61,9 @@ namespace MaterialUI {
 				
 				return;
 			}
-			
-			string penumbraConfigPath = Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "/XIVLauncher/PluginConfigs/Penumbra.json");
-			if(!File.Exists(penumbraConfigPath)) {
+
+			string penumbraConfigPath = Path.Combine(this.pluginInterface.ConfigDirectory.FullName, "../Penumbra.json");
+			if (!File.Exists(penumbraConfigPath)) {
 				penumbraIssue = "Can't find Penumbra Config.";
 				
 				return;

--- a/plugin/MaterialUI.cs
+++ b/plugin/MaterialUI.cs
@@ -61,8 +61,8 @@ namespace MaterialUI {
 				
 				return;
 			}
-
-			string penumbraConfigPath = Path.Combine(this.pluginInterface.ConfigDirectory.FullName, "../Penumbra.json");
+			
+			string penumbraConfigPath = $"{pluginInterface.ConfigFile.DirectoryName}/Penumbra.json";
 			if (!File.Exists(penumbraConfigPath)) {
 				penumbraIssue = "Can't find Penumbra Config.";
 				

--- a/plugin/UI.cs
+++ b/plugin/UI.cs
@@ -159,7 +159,7 @@ namespace MaterialUI {
 									styleOverrides[val.Key] = val.Value;
 						}
 						
-						DalamudStyle.Apply(main.config, styleOverrides);
+						DalamudStyle.Apply(main, styleOverrides);
 					}
 					
 					ImGui.SameLine();

--- a/plugin/Updater.cs
+++ b/plugin/Updater.cs
@@ -454,8 +454,8 @@ namespace MaterialUI {
 					return;
 				
 				List<string> optionsNew = new List<string>();
-				string penumbraConfigPath = Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "/XIVLauncher/PluginConfigs/Penumbra.json");
-				if(File.Exists(penumbraConfigPath)) {
+				string penumbraConfigPath = Path.Combine(main.pluginInterface.ConfigDirectory.FullName, "../Penumbra.json");
+				if (File.Exists(penumbraConfigPath)) {
 					dynamic penumbraData = JsonConvert.DeserializeObject(File.ReadAllText(penumbraConfigPath));
 					string penumbraPath = (string)penumbraData?.ModDirectory;
 					if(penumbraPath != "") {
@@ -557,7 +557,7 @@ namespace MaterialUI {
 			if(main.penumbraIssue != null)
 				return false;
 			
-			string penumbraConfigPath = Path.GetFullPath(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData) + "/XIVLauncher/PluginConfigs/Penumbra.json");
+			string penumbraConfigPath = Path.Combine(main.pluginInterface.ConfigDirectory.FullName, "../Penumbra.json");
 			dynamic penumbraData = JsonConvert.DeserializeObject(File.ReadAllText(penumbraConfigPath));
 			string penumbraPath = (string)penumbraData?.ModDirectory;
 			

--- a/plugin/Updater.cs
+++ b/plugin/Updater.cs
@@ -454,7 +454,7 @@ namespace MaterialUI {
 					return;
 				
 				List<string> optionsNew = new List<string>();
-				string penumbraConfigPath = Path.Combine(main.pluginInterface.ConfigDirectory.FullName, "../Penumbra.json");
+				string penumbraConfigPath = $"{main.pluginInterface.ConfigFile.DirectoryName}/Penumbra.json";
 				if (File.Exists(penumbraConfigPath)) {
 					dynamic penumbraData = JsonConvert.DeserializeObject(File.ReadAllText(penumbraConfigPath));
 					string penumbraPath = (string)penumbraData?.ModDirectory;
@@ -557,7 +557,7 @@ namespace MaterialUI {
 			if(main.penumbraIssue != null)
 				return false;
 			
-			string penumbraConfigPath = Path.Combine(main.pluginInterface.ConfigDirectory.FullName, "../Penumbra.json");
+			string penumbraConfigPath = $"{main.pluginInterface.ConfigFile.DirectoryName}/Penumbra.json";
 			dynamic penumbraData = JsonConvert.DeserializeObject(File.ReadAllText(penumbraConfigPath));
 			string penumbraPath = (string)penumbraData?.ModDirectory;
 			


### PR DESCRIPTION
I think this fix should make the config path compatible with both goat(XIVLauncher) Dalamud and otter(CN) Dalamud.