### PR TITLE
Updated for Dawntrail.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Check out Material UI by skotlex [here](https://github.com/skotlex/ffxiv-material-ui)
+Check out Material UI by skotlex (maintained by Tunnelbliick) [here](https://github.com/Tunnelbliick/ffxiv-material-ui)
 
 ![preview](images/preview.png)
 

--- a/plugin/MaterialUI.cs
+++ b/plugin/MaterialUI.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using System.IO;
 using Dalamud.Plugin.Services;
 using Dalamud.Logging;
+using Dalamud.IoC;
 
 namespace MaterialUI {
 	public class MaterialUI : IDalamudPlugin {
@@ -14,13 +15,15 @@ namespace MaterialUI {
 		
 		public string penumbraIssue {get; private set;} = null;
 		
-		public DalamudPluginInterface pluginInterface {get; private set;}
+		public IDalamudPluginInterface pluginInterface {get; private set;}
 		public ICommandManager commandManager {get; private set;}
-		public UI ui {get; private set;}
+		public IPluginLog pluginLog {get; private set;}
+        //[PluginService] public static IPluginLog pluginLog { get; set; } = null!;
+        public UI ui {get; private set;}
 		public Config config {get; private set;}
 		public Updater updater {get; private set;}
 		
-		public MaterialUI(DalamudPluginInterface pluginInterface, ICommandManager commandManager) {
+		public MaterialUI(IDalamudPluginInterface pluginInterface, ICommandManager commandManager) {
 			this.pluginInterface = pluginInterface;
 			this.commandManager = commandManager;
 			
@@ -58,7 +61,7 @@ namespace MaterialUI {
 			try {
 				pluginInterface.GetIpcSubscriber<(int, int)>("Penumbra.ApiVersions").InvokeFunc();
 			} catch(Exception e) {
-				PluginLog.Error("Penumbra.ApiVersions failed", e);
+				pluginLog.Error("Penumbra.ApiVersions failed", e);
 				penumbraIssue = "Penumbra not found.";
 				
 				return;

--- a/plugin/MaterialUI.json
+++ b/plugin/MaterialUI.json
@@ -5,8 +5,8 @@
 	"Description": "Auto updating Material UI with customizable accent color and more. Icon by Meconate",
 	"InternalName": "MaterialUI",
 	"ApplicableVersion": "any",
-	"DalamudApiLevel": 9,
+	"DalamudApiLevel": 10,
 	"LoadPriority": 1,
-	"Tags": ["ui", "penumbra", "material", "skotlex", "sevii", "accent", "color"],
+	"Tags": ["ui", "penumbra", "material", "skotlex", "sevii", "Tunnelbliick", "Tensounder54", "accent", "color"],
 	"IconUrl": "https://raw.githubusercontent.com/Sevii77/ffxiv_materialui_accent/master/images/icon.png"
 }

--- a/plugin/Updater.cs
+++ b/plugin/Updater.cs
@@ -154,7 +154,7 @@ namespace MaterialUI {
 	}
 	
 	public class Updater {
-		public const string repoMaster = "skotlex/ffxiv-material-ui";
+		public const string repoMaster = "Tunnelbliick/ffxiv-material-ui";
 		public const string repoAccent = "sevii77/ffxiv_materialui_accent";
 		
 		private HttpClient httpClient;

--- a/repo.json
+++ b/repo.json
@@ -4,11 +4,11 @@
 		"Name": "Material UI",
 		"Description": "Auto updating Material UI with customizable accent color and more. Icon by Mek",
 		"InternalName": "MaterialUI",
-		"AssemblyVersion": "1.4.13",
-		"TestingAssemblyVersion": "1.4.13",
+		"AssemblyVersion": "1.5.0",
+		"TestingAssemblyVersion": "1.5.0",
 		"RepoUrl": "https://github.com/Sevii77/ffxiv_materialui_accent",
 		"ApplicableVersion": "any",
-		"DalamudApiLevel": 9,
+		"DalamudApiLevel": 10,
 		"IsHide": "False",
 		"IsTestingExclusive": "False",
 		"DownloadCount": 0,
@@ -17,6 +17,6 @@
 		"DownloadLinkTesting": "https://github.com/Sevii77/ffxiv_materialui_accent/raw/master/release.zip",
 		"DownloadLinkUpdate": "https://github.com/Sevii77/ffxiv_materialui_accent/raw/master/release.zip",
 		"IconUrl": "https://raw.githubusercontent.com/Sevii77/ffxiv_materialui_accent/master/images/icon.png",
-		"Tags": ["ui", "penumbra", "material", "skotlex", "sevii", "accent", "color"]
+		"Tags": ["ui", "penumbra", "material", "skotlex", "sevii", "Tunnelbliick", "Tensounder54", "accent", "color"]
 	}
 ]


### PR DESCRIPTION
Rolled version numbers forward, applied fixes to account for Dalamud v10 and pointed to material ui fork.

Now points to: https://github.com/Tunnelbliick/ffxiv-material-ui
